### PR TITLE
Updated vCPU allocation for the new version of AWS Ground Station Agent.

### DIFF
--- a/ga-snpp-wb-ec2-poc-latest.yml
+++ b/ga-snpp-wb-ec2-poc-latest.yml
@@ -314,6 +314,8 @@ Resources:
 
               echo AWS_DEFAULT_REGION=${AWS::Region} >> /etc/environment
 
+              export DEBIAN_FRONTEND=noninteractive
+              
               # uninstall old AWS CLIv1
               apt-get update
               apt-get remove awscli
@@ -344,7 +346,7 @@ Resources:
                     "${EIP}"
                   ],
                   "agentCpuCores": [
-                    2, 3, 4, 5, 6, 7, 8, 9, 50, 51, 52, 53, 54, 55, 56, 57
+                    2, 3, 4, 5, 6, 7, 8, 9, 10, 50, 51, 52, 53, 54, 55, 56, 57, 58
                   ]
                 }
               }

--- a/modem_ami/dsp/blink-dsp-start
+++ b/modem_ami/dsp/blink-dsp-start
@@ -29,11 +29,11 @@ export PATH=$PATH:/usr/local/cuda/lib64
 
 # If using collocated AWS GS agent, input protocol for Blink must be UDP.
 # We must isolate cores which have been pinned with irq_affinity script to minimize UDP loss, as well from GS agent cores
-# for g4dn.metal, they are 0, 1, 24, 25, 48, 49, 72, 73 (kernel), and 2-9, 50-57 (agent)
+# for g4dn.metal, they are 0, 1, 24, 25, 48, 49, 72, 73 (kernel), and 2-10, 50-58 (agent)
 # for g4dn.12xlarge they are 0, 1, 48, 49
 # refer to AWS GS agent manual for detailed explanation
 
-taskset -a -c 10-23,26-47,58-71,74-94 /usr/share/blink-dsp/bin/blink-dsp \
+taskset -a -c 11-23,26-47,59-71,74-94 /usr/share/blink-dsp/bin/blink-dsp \
 -l $BLNK_DSP_LISTEN_PORT \
 -u $BLNK_DSP_IN_PORT \
 -c CCSDS_VITA_Suomi_BW350.xml \

--- a/modem_ami/install.sh
+++ b/modem_ami/install.sh
@@ -107,9 +107,9 @@ systemctl restart blink-config.service
  sleep 2
 
 echo -e "Changing MNC docker container's CPU affinities"
-docker update --cpuset-cpus 10-23,26-47,58-71,74-94 mnc_nginx
-docker update --cpuset-cpus 10-23,26-47,58-71,74-94 mnc_standalone
-docker update --cpuset-cpus 10-23,26-47,58-71,74-94 mncdocker-timescaledb-1
-docker update --cpuset-cpus 10-23,26-47,58-71,74-94 mnc_postgres
+docker update --cpuset-cpus 11-23,26-47,59-71,74-94 mnc_nginx
+docker update --cpuset-cpus 11-23,26-47,59-71,74-94 mnc_standalone
+docker update --cpuset-cpus 11-23,26-47,59-71,74-94 mncdocker-timescaledb-1
+docker update --cpuset-cpus 11-23,26-47,59-71,74-94 mnc_postgres
 
 echo -e "Blink modem configuration pack installation complete."


### PR DESCRIPTION
Updated vCPU allocation for the new version of AWS Ground Station Agent, as described in https://aws.amazon.com/blogs/publicsector/how-to-migrate-to-the-new-aws-ground-station-agent-launching-march-28/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
